### PR TITLE
fix: Handle parsing errors for last message in chat with friend

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -26,7 +26,36 @@ export default async function Home() {
         -1
       )) as string[];
 
-      const lastMessage = JSON.parse(lastMessageRaw) as Message;
+      if (lastMessageRaw === undefined) {
+        console.warn(`No last message found for chat with friend ${friend.id}`);
+        return {
+          ...friend,
+          lastMessage: {
+            id: '',
+            senderId: '',
+            receiverId: '',
+            text: '',
+            timestamp: 0,
+          },
+        };
+      }
+
+      let lastMessage;
+      try {
+        lastMessage = JSON.parse(lastMessageRaw) as Message;
+      } catch (error) {
+        console.error(
+          `Error parsing last message for chat with friend ${friend.id}:`,
+          error
+        );
+        lastMessage = {
+          id: '',
+          senderId: '',
+          receiverId: '',
+          text: 'Error loading message',
+          timestamp: 0,
+        };
+      }
 
       return {
         ...friend,


### PR DESCRIPTION
Handle the case where there is an error parsing the last message in the chat with a friend. If an error occurs, display an error message and set a default last message object with empty values. This prevents the application from crashing and provides a better user experience.